### PR TITLE
Set window to 50% screen size

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -34,7 +34,13 @@ class MainWindow(QMainWindow):
     def __init__(self):
         super().__init__()
         self.setWindowTitle("Trình Quản Lý Khóa")
-        self.setFixedSize(1000, 640)
+        
+        # Set window size to 50% of screen size
+        screen = QGuiApplication.primaryScreen()
+        screen_geometry = screen.availableGeometry()
+        width = int(screen_geometry.width() * 0.5)
+        height = int(screen_geometry.height() * 0.5)
+        self.setFixedSize(width, height)
 
         self.manager = KeyManager()
 


### PR DESCRIPTION
Set the main window size to 50% of the user's screen to improve responsiveness across different screen sizes.

---
<a href="https://cursor.com/background-agent?bcId=bc-99092437-eb2d-4478-b1ab-6c39e9a0e882">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-99092437-eb2d-4478-b1ab-6c39e9a0e882">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

